### PR TITLE
Fix: message options bug

### DIFF
--- a/src/components/BotUI.vue
+++ b/src/components/BotUI.vue
@@ -154,6 +154,7 @@ export default {
       this.botActive = !this.botActive
 
       if (this.botActive) {
+        EventBus.$on('select-button-option', this.selectOption)
         this.$emit('init')
       } else {
         EventBus.$off('select-button-option')


### PR DESCRIPTION
After deactivating the bot, the 'select-button-option' turns off. It is only turned on on create hook, but that happens only once. Turning on the 'select-button-option' before emitting 'init' fixes that.